### PR TITLE
Feature/improvements fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 
-***January 11, 2021*** - [Euromessage v4.3.5](https://github.com/relateddigital/euromessage-android/releases/tag/4.3.5)
+***January 18, 2021*** - [Euromessage v4.3.6](https://github.com/relateddigital/euromessage-android/releases/tag/4.3.6)
 
  **Bintray** [ ![Bintray Maven Download](https://api.bintray.com/packages/visilabs/euromessage/euromessage/images/download.svg) ](https://bintray.com/visilabs/euromessage/euromessage/_latestVersion)
 
@@ -35,7 +35,7 @@ The Euromessage Android Sdk is a java implementation of an Android client for Eu
 Add Euromessage to the ```dependencies``` in app/build.gradle.
 
 ```java
-implementation 'com.euromsg:euromsg:4.3.5'
+implementation 'com.euromsg:euromsg:4.3.6'
 ```
 
 ## 2. Usage of SDK 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,10 +42,6 @@ dependencies {
 
     implementation 'com.android.support:multidex:1.0.3'
 
-    //RxJava - RxAndroid
-    implementation 'io.reactivex.rxjava3:rxjava:3.0.9'
-    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
-
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 17
         targetSdkVersion 30
         versionCode 1
-        versionName "4.3.5"
+        versionName "4.3.6"
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "com.relateddigital.euromessage"
         minSdkVersion 17
         targetSdkVersion 30
         versionCode 1
-        versionName "4.3.3"
+        versionName "4.3.5"
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -33,14 +33,14 @@ dependencies {
     implementation project(':euromsg')
 
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation "com.visilabs.android:visilabs-android:3.2.0"
+    implementation "com.visilabs.android:visilabs-android:5.3.1"
 
     //Retrofit
-    implementation "com.squareup.retrofit2:retrofit:2.4.0"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:2.4.0"
-    implementation "com.squareup.retrofit2:converter-gson:2.4.0"
+    implementation "com.squareup.retrofit2:retrofit:2.9.0"
+    implementation "com.squareup.retrofit2:adapter-rxjava2:2.9.0"
+    implementation "com.squareup.retrofit2:converter-gson:2.9.0"
 
-    implementation 'com.android.support:multidex:1.0.3'
+    implementation "androidx.multidex:multidex:2.0.1"
 
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
@@ -49,5 +49,3 @@ dependencies {
 
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.huawei.agconnect'
-
-

--- a/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
+++ b/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
@@ -302,7 +302,7 @@ public class MainActivity extends AppCompatActivity {
                 int notificationId = new Random().nextInt();
                 PushNotificationManager pushNotificationManager = new PushNotificationManager();
                 Message message = new Gson().fromJson(TestPush.testImage, Message.class);
-                pushNotificationManager.generateNotification(getApplicationContext(), message, AppUtils.getBitmap(message.getMediaUrl()),notificationId);
+                pushNotificationManager.generateNotification(getApplicationContext(), message, AppUtils.getBitMapFromUri(message.getMediaUrl()),notificationId);
             }
         });
 

--- a/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
+++ b/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
@@ -201,16 +201,19 @@ public class MainActivity extends AppCompatActivity {
         sendATemplatePush();
         String huaweiToken = SP.getString(getApplicationContext(), "HuaweiToken");
         String firabaseToken = SP.getString(getApplicationContext(), "FirebaseToken");
-        if(firabaseToken.equals("")){
-            getFirabaseToken();
+        
+        if (EuroMobileManager.checkPlayService(getApplicationContext())) {
+            if(firabaseToken.equals("")){
+                getFirabaseToken();
+            } else {
+                etFirebaseToken.setText(firabaseToken);
+            }
         } else {
-            etFirebaseToken.setText(firabaseToken);
-        }
-
-        if(huaweiToken.equals("")){
-            getHuaweiToken();
-        } else {
-            etHuaweiToken.setText(huaweiToken);
+            if(huaweiToken.equals("")){
+                getHuaweiToken();
+            } else {
+                etHuaweiToken.setText(huaweiToken);
+            }
         }
 
         tvRelease.setText("Appv : " + BuildConfig.VERSION_NAME + " " + " EM SDKv: " + BuildConfig.VERSION_NAME);

--- a/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
+++ b/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
@@ -23,7 +23,6 @@ import android.widget.Toast;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.BuildConfig;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
+++ b/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
@@ -30,6 +30,7 @@ import com.google.gson.reflect.TypeToken;
 import com.huawei.agconnect.config.AGConnectServicesConfig;
 import com.huawei.hms.aaid.HmsInstanceId;
 import com.huawei.hms.common.ApiException;
+import com.relateddigital.euromessage.databinding.ActivityMainBinding;
 import com.visilabs.Visilabs;
 
 import java.lang.reflect.Type;
@@ -52,34 +53,14 @@ import euromsg.com.euromobileandroid.utils.AppUtils;
 public class MainActivity extends AppCompatActivity {
 
     private static final int FIRST_ITEM_CAROUSEL = 0;
-
-    AutoCompleteTextView autotext, registeremailAutotext;
-    Button btnSync, btnText, btnImage, btnCarousel, btnRegisteremail;
-    TextView tvRelease, tvLastPushTime;
-    EditText etFirebaseToken, etHuaweiToken;
-    Spinner registeremailCommercialSpinner, registeremailPermitSpinner;
-    TableLayout tlPushParams;
+    private ActivityMainBinding binding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-
-        autotext = findViewById(R.id.autotext);
-        btnSync = findViewById(R.id.btn_sync);
-        btnCarousel = findViewById(R.id.btn_carousel);
-        btnText = findViewById(R.id.btn_text);
-        btnImage = findViewById(R.id.btn_image);
-        tvRelease = findViewById(R.id.tvRelease);
-        etFirebaseToken = findViewById(R.id.et_token);
-        etHuaweiToken = findViewById(R.id.et_huawei_token);
-
-        registeremailAutotext = findViewById(R.id.registeremail_autotext);
-        btnRegisteremail = findViewById(R.id.btn_registeremail);
-        registeremailCommercialSpinner = findViewById(R.id.registeremailcommercial_spinner);
-        registeremailPermitSpinner = findViewById(R.id.registeremailpermit_spinner);
-        tlPushParams = findViewById(R.id.tl_push_params);
-        tvLastPushTime = findViewById(R.id.tv_last_push_time);
+        binding = ActivityMainBinding.inflate(getLayoutInflater());
+        View view = binding.getRoot();
+        setContentView(view);
 
         createSpinners();
         visilabsAdvertisement();
@@ -91,12 +72,12 @@ public class MainActivity extends AppCompatActivity {
         String[] registeremailCommercialSpinnerItems = new String[]{ Constants.EURO_RECIPIENT_TYPE_BIREYSEL, Constants.EURO_RECIPIENT_TYPE_TACIR };
         ArrayAdapter aa1 = new ArrayAdapter(this,android.R.layout.simple_spinner_item, registeremailCommercialSpinnerItems);
         aa1.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        registeremailCommercialSpinner.setAdapter(aa1);
+        binding.registeremailcommercialSpinner.setAdapter(aa1);
 
         String[] registeremailPermitSpinnerItems = new String[]{ Constants.EMAIL_PERMIT_ACTIVE, Constants.EMAIL_PERMIT_PASSIVE };
         ArrayAdapter aa2 = new ArrayAdapter(this,android.R.layout.simple_spinner_item, registeremailPermitSpinnerItems);
         aa2.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        registeremailPermitSpinner.setAdapter(aa2);
+        binding.registeremailpermitSpinner.setAdapter(aa2);
 
     }
 
@@ -146,11 +127,11 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void setPushParamsUI() {
-        int rowCount = tlPushParams.getChildCount();
+        int rowCount = binding.tlPushParams.getChildCount();
         if (rowCount > 2) {
-            tlPushParams.removeViews(2, rowCount - 2);
+            binding.tlPushParams.removeViews(2, rowCount - 2);
         }
-        tvLastPushTime.setText(SP.getString(getApplicationContext(), Constants.LAST_PUSH_TIME));
+        binding.tvLastPushTime.setText(SP.getString(getApplicationContext(), Constants.LAST_PUSH_TIME));
         String lastPushParamsString = SP.getString(getApplicationContext(), Constants.LAST_PUSH_PARAMS);
         Gson gson = new Gson();
         Type paramsType = new TypeToken<Map<String, String>>() {}.getType();
@@ -192,7 +173,7 @@ public class MainActivity extends AppCompatActivity {
         tr.addView(tvKey);
         tr.addView(tvValue);
 
-        tlPushParams.addView(tr, new TableLayout.LayoutParams(TableLayout.LayoutParams.WRAP_CONTENT, TableLayout.LayoutParams.WRAP_CONTENT));
+        binding.tlPushParams.addView(tr, new TableLayout.LayoutParams(TableLayout.LayoutParams.WRAP_CONTENT, TableLayout.LayoutParams.WRAP_CONTENT));
     }
 
 
@@ -205,24 +186,24 @@ public class MainActivity extends AppCompatActivity {
             if(firabaseToken.equals("")){
                 getFirabaseToken();
             } else {
-                etFirebaseToken.setText(firabaseToken);
+                binding.etToken.setText(firabaseToken);
             }
         } else {
             if(huaweiToken.equals("")){
                 getHuaweiToken();
             } else {
-                etHuaweiToken.setText(huaweiToken);
+                binding.etHuaweiToken.setText(huaweiToken);
             }
         }
 
-        tvRelease.setText("Appv : " + com.relateddigital.euromessage.BuildConfig.VERSION_NAME + " " + " EM SDKv: " + euromsg.com.euromobileandroid.BuildConfig.VERSION_NAME);
-        btnSync.setOnClickListener(new View.OnClickListener() {
+        binding.tvRelease.setText("Appv : " + com.relateddigital.euromessage.BuildConfig.VERSION_NAME + " " + " EM SDKv: " + euromsg.com.euromobileandroid.BuildConfig.VERSION_NAME);
+        binding.btnSync.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 sync();
             }
         });
-        btnRegisteremail.setOnClickListener(new View.OnClickListener() {
+        binding.btnRegisteremail.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 registerEmail();
@@ -231,7 +212,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void registerEmail() {
-        if (registeremailAutotext.getText().toString().equals("")) {
+        if (binding.registeremailAutotext.getText().toString().equals("")) {
             Toast.makeText(getApplicationContext(), "Please Enter Email", Toast.LENGTH_LONG).show();
 
         } else {
@@ -252,30 +233,30 @@ public class MainActivity extends AppCompatActivity {
             };
 
             boolean isCommercial = false;
-            String isCommercialText = String.valueOf(registeremailCommercialSpinner.getSelectedItem());
+            String isCommercialText = String.valueOf(binding.registeremailcommercialSpinner.getSelectedItem());
             if(isCommercialText.equals(Constants.EURO_RECIPIENT_TYPE_TACIR)) {
                 isCommercial = true;
             }
 
             EmailPermit emailPermit = EmailPermit.ACTIVE;
-            String isEmailPermitActiveText = String.valueOf(registeremailPermitSpinner.getSelectedItem());
+            String isEmailPermitActiveText = String.valueOf(binding.registeremailpermitSpinner.getSelectedItem());
             if(isEmailPermitActiveText.equals(Constants.EMAIL_PERMIT_PASSIVE)) {
                 emailPermit = EmailPermit.PASSIVE;
             }
 
-            EuroMobileManager.getInstance().registerEmail(registeremailAutotext.getText().toString().trim(), emailPermit, isCommercial, getApplicationContext(), callback);
+            EuroMobileManager.getInstance().registerEmail(binding.registeremailAutotext.getText().toString().trim(), emailPermit, isCommercial, getApplicationContext(), callback);
             Toast.makeText(getApplicationContext(), "Check RMC", Toast.LENGTH_LONG).show();
         }
     }
 
     private void sync() {
 
-        if (autotext.getText().toString().equals("")) {
+        if (binding.autotext.getText().toString().equals("")) {
             Toast.makeText(getApplicationContext(), "Please Enter Email", Toast.LENGTH_LONG).show();
 
         } else {
             EuroMobileManager.getInstance().setGsmPermit(GsmPermit.ACTIVE, getApplicationContext());
-            EuroMobileManager.getInstance().setEmail(autotext.getText().toString().trim(), getApplicationContext());
+            EuroMobileManager.getInstance().setEmail(binding.autotext.getText().toString().trim(), getApplicationContext());
             EuroMobileManager.getInstance().setEuroUserId("12345", getApplicationContext());
             EuroMobileManager.getInstance().sync(getApplicationContext());
             Toast.makeText(getApplicationContext(), "Check RMC", Toast.LENGTH_LONG).show();
@@ -284,7 +265,7 @@ public class MainActivity extends AppCompatActivity {
 
     public void sendATemplatePush() {
 
-        btnText.setOnClickListener(new View.OnClickListener() {
+        binding.btnText.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 int notificationId = new Random().nextInt();
@@ -295,7 +276,7 @@ public class MainActivity extends AppCompatActivity {
         });
 
 
-        btnImage.setOnClickListener(new View.OnClickListener() {
+        binding.btnImage.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 int notificationId = new Random().nextInt();
@@ -305,7 +286,7 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        btnCarousel.setOnClickListener(new View.OnClickListener() {
+        binding.btnCarousel.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 int notificationId = new Random().nextInt();
@@ -324,8 +305,7 @@ public class MainActivity extends AppCompatActivity {
         Visilabs.CreateAPI(Constants.ORGANIZATION_ID, Constants.SITE_ID, "http://lgr.visilabs.net",
                 Constants.DATASOURCE, "http://rt.visilabs.net", "Android", getApplicationContext(), "http://s.visilabs.net/json", "http://s.visilabs.net/actjson", 30000, "http://s.visilabs.net/geojson", true);
 
-        Button btnInnApp = findViewById(R.id.btn_in_app);
-        btnInnApp.setOnClickListener(new View.OnClickListener() {
+        binding.btnInApp.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 HashMap<String, String> parameters = new HashMap<>();
@@ -335,8 +315,7 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        Button btnInfo = findViewById(R.id.btn_info);
-        btnInfo.setOnClickListener(new View.OnClickListener() {
+        binding.btnInfo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 String url = "http://www.visilabs.com";
@@ -355,7 +334,7 @@ public class MainActivity extends AppCompatActivity {
                         if (!task.isSuccessful()) {
                             return;
                         }
-                        etFirebaseToken.setText(task.getResult());
+                        binding.etToken.setText(task.getResult());
                     }
                 });
     }
@@ -371,7 +350,7 @@ public class MainActivity extends AppCompatActivity {
                     runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            etHuaweiToken.setText(token);
+                            binding.etHuaweiToken.setText(token);
                         }
                     });
 

--- a/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
+++ b/app/src/main/java/com/relateddigital/euromessage/MainActivity.java
@@ -216,7 +216,7 @@ public class MainActivity extends AppCompatActivity {
             }
         }
 
-        tvRelease.setText("Appv : " + BuildConfig.VERSION_NAME + " " + " EM SDKv: " + BuildConfig.VERSION_NAME);
+        tvRelease.setText("Appv : " + com.relateddigital.euromessage.BuildConfig.VERSION_NAME + " " + " EM SDKv: " + euromsg.com.euromobileandroid.BuildConfig.VERSION_NAME);
         btnSync.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/euromsg/build.gradle
+++ b/euromsg/build.gradle
@@ -17,7 +17,7 @@ ext {
     siteUrl = 'https://www.euromsg.com/'
     gitUrl = 'https://www.euromsg.com/'
 
-    libraryVersion = '4.3.5'
+    libraryVersion = '4.3.6'
 
     developerId = 'visilabs'
     developerName = 'Visilabs'
@@ -36,8 +36,8 @@ android {
         minSdkVersion 17
         targetSdkVersion 30
         versionCode 1
-        versionName "4.3.5"
-        buildConfigField 'String', 'VERSION_NAME', "\"4.3.5\""
+        versionName "4.3.6"
+        buildConfigField 'String', 'VERSION_NAME', "\"4.3.6\""
     }
     buildTypes {
         release {
@@ -61,7 +61,6 @@ dependencies {
     api "com.squareup.okhttp3:okhttp:4.9.0"
     api "com.squareup.okhttp3:logging-interceptor:4.9.0"
     api "androidx.core:core-ktx:1.3.2"
-    api 'com.squareup.picasso:picasso:2.71828'
     api 'com.huawei.agconnect:agconnect-core:1.4.2.301'
     api 'com.huawei.hms:push:5.0.4.302'
 }

--- a/euromsg/build.gradle
+++ b/euromsg/build.gradle
@@ -30,7 +30,7 @@ ext {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion '30.0.2'
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion 17
@@ -55,15 +55,15 @@ dependencies {
     api 'com.google.code.gson:gson:2.8.6'
     api 'com.google.firebase:firebase-messaging:21.0.1'
     api "com.google.code.gson:gson:2.8.6"
-    api "com.squareup.retrofit2:retrofit:2.4.0"
-    api "com.squareup.retrofit2:adapter-rxjava2:2.4.0"
-    api "com.squareup.retrofit2:converter-gson:2.4.0"
-    api "com.squareup.okhttp3:okhttp:3.12.1"
-    api "com.squareup.okhttp3:logging-interceptor:3.10.0"
+    api "com.squareup.retrofit2:retrofit:2.9.0"
+    api "com.squareup.retrofit2:adapter-rxjava2:2.9.0"
+    api "com.squareup.retrofit2:converter-gson:2.9.0"
+    api "com.squareup.okhttp3:okhttp:4.9.0"
+    api "com.squareup.okhttp3:logging-interceptor:4.9.0"
     api "androidx.core:core-ktx:1.3.2"
     api 'com.squareup.picasso:picasso:2.71828'
-    api 'com.huawei.agconnect:agconnect-core:1.4.1.300'
-    api 'com.huawei.hms:push:5.0.0.300'
+    api 'com.huawei.agconnect:agconnect-core:1.4.2.301'
+    api 'com.huawei.hms:push:5.0.4.302'
 }
 
 allprojects {

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/Constants.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/Constants.java
@@ -53,6 +53,4 @@ public class Constants {
 
     public static final String INTENT_NAME = "intent_name";
 
-    public static final String TOKEN_KEY = "token-key";
-
 }

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/Constants.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/Constants.java
@@ -53,4 +53,6 @@ public class Constants {
 
     public static final String INTENT_NAME = "intent_name";
 
+    public static final String TOKEN_KEY = "token-key";
+
 }

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/Constants.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/Constants.java
@@ -3,7 +3,7 @@ package euromsg.com.euromobileandroid;
 public class Constants {
 
     //https://commonsware.com/blog/2020/10/14/android-studio-4p1-library-modules-version-code.html
-    static final String SDK_VERSION = "4.3.5";//TODO: BuildConfig.VERSION_NAME;
+    static final String SDK_VERSION = euromsg.com.euromobileandroid.BuildConfig.VERSION_NAME;
 
 
     static final String EURO_CONSENT_TIME_KEY = "ConsentTime";

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
@@ -120,7 +120,7 @@ public class EuroMobileManager {
 
             retention.setPushId(pushId);
             retention.setStatus(MessageStatus.Received.toString());
-            retention.setToken(subscription.getToken());
+            retention.setToken(SharedPreference.getString(mContext, Constants.TOKEN_KEY));
 
             apiInterface = RetentionApiClient.getClient().create(EuroApiService.class);
             Call<Void> call1 = apiInterface.report(retention);
@@ -197,6 +197,8 @@ public class EuroMobileManager {
 
     public void subscribe(String token, Context context) {
         this.subscription.setToken(token);
+
+        SharedPreference.saveString(context, Constants.TOKEN_KEY, token);
 
         setDefaultPushPermit(context);
 

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
@@ -556,7 +556,7 @@ public class EuroMobileManager {
     public void registerEmail(String email, EmailPermit emailPermit, Boolean isCommercial, Context context, final EuromessageCallback callback){
         setEmail(email, context);
         setEmailPermit(emailPermit, context);
-        Subscription registerEmailSubscription = null;
+        Subscription registerEmailSubscription;
         try {
             registerEmailSubscription = (Subscription) this.subscription.clone();
             registerEmailSubscription.add(Constants.EURO_CONSENT_SOURCE_KEY, Constants.EURO_CONSENT_SOURCE_VALUE);

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
@@ -106,44 +106,6 @@ public class EuroMobileManager {
         return instance;
     }
 
-    public void reportReceived(String pushId) {
-
-        if (pushId != null) {
-            EuroLogger.debugLog("Report Received : " + pushId);
-
-            Retention retention = new Retention();
-            if (checkPlayService(mContext)) {
-                retention.setKey(firebaseAppAlias);
-            } else {
-                retention.setKey(huaweiAppAlias);
-            }
-
-            retention.setPushId(pushId);
-            retention.setStatus(MessageStatus.Received.toString());
-            retention.setToken(SharedPreference.getString(mContext, Constants.TOKEN_KEY));
-
-            apiInterface = RetentionApiClient.getClient().create(EuroApiService.class);
-            Call<Void> call1 = apiInterface.report(retention);
-            call1.enqueue(new Callback<Void>() {
-                @Override
-                public void onResponse(@NonNull Call<Void> call, @NonNull Response<Void> response) {
-
-                    if (response.isSuccessful()) {
-                        Log.d("ReportReceived", "Success");
-                    }
-                }
-
-                @Override
-                public void onFailure(@NonNull Call<Void> call, @NonNull Throwable t) {
-                    call.cancel();
-                }
-            });
-
-        } else {
-            EuroLogger.debugLog("reportReceived : Push Id cannot be null!");
-        }
-    }
-
     public void registerToFCM(final Context context) {
         FirebaseApp.initializeApp(context);
     }
@@ -191,14 +153,8 @@ public class EuroMobileManager {
         }
     }
 
-    public void reportReceived(Message message) throws Exception {
-        reportReceived(message.getPushId());
-    }
-
     public void subscribe(String token, Context context) {
         this.subscription.setToken(token);
-
-        SharedPreference.saveString(context, Constants.TOKEN_KEY, token);
 
         setDefaultPushPermit(context);
 

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/EuroMobileManager.java
@@ -268,7 +268,7 @@ public class EuroMobileManager {
         });
     }
 
-    private boolean isSubscriptionAllReadySent(Context context) {
+    private boolean isSubscriptionAlreadySent(Context context) {
 
         boolean value = false;
         if (SharedPreference.getString(context, Constants.EURO_SUBSCRIPTION_KEY).equals(SharedPreference.getString(context, Constants.ALREADY_SENT_SUBSCRIPTION_JSON))) {
@@ -521,7 +521,7 @@ public class EuroMobileManager {
     public boolean shouldSendSubscription(Context context) throws ParseException {
         boolean value ;
 
-        if (isSubscriptionAllReadySent(context)) {
+        if (isSubscriptionAlreadySent(context)) {
 
             if (!SharedPreference.getString(context, Constants.LAST_SUBSCRIPTION_TIME).equals("")) {
 

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/connection/EuroApiService.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/connection/EuroApiService.java
@@ -1,17 +1,11 @@
 package euromsg.com.euromobileandroid.connection;
 
-import euromsg.com.euromobileandroid.model.Message;
 import euromsg.com.euromobileandroid.model.Retention;
 import euromsg.com.euromobileandroid.model.Subscription;
 import retrofit2.Call;
 import retrofit2.http.Body;
-import retrofit2.http.FormUrlEncoded;
-import retrofit2.http.GET;
-import retrofit2.http.Header;
 import retrofit2.http.Headers;
 import retrofit2.http.POST;
-import retrofit2.http.Path;
-import retrofit2.http.Query;
 
 public interface EuroApiService {
 

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/connection/interceptor/RawResponseInterceptor.kt
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/connection/interceptor/RawResponseInterceptor.kt
@@ -4,6 +4,7 @@ package euromsg.com.euromobileandroid.connection.interceptor
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
+import kotlin.jvm.Throws
 
 
 open class RawResponseInterceptor : Interceptor {

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/model/Subscription.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/model/Subscription.java
@@ -66,7 +66,7 @@ public class Subscription extends BaseRequest implements Cloneable {
     }
 
     public boolean isValid() {
-        return !(TextUtils.isEmpty(getToken()) || TextUtils.isEmpty(appAlias));
+        return !(TextUtils.isEmpty(getToken()) && TextUtils.isEmpty(appAlias));
     }
 
     public Map<String, Object> getExtra() {

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/model/Subscription.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/model/Subscription.java
@@ -66,7 +66,7 @@ public class Subscription extends BaseRequest implements Cloneable {
     }
 
     public boolean isValid() {
-        return !(TextUtils.isEmpty(getToken()) && TextUtils.isEmpty(appAlias));
+        return !(TextUtils.isEmpty(getToken()) || TextUtils.isEmpty(appAlias));
     }
 
     public Map<String, Object> getExtra() {

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/model/Subscription.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/model/Subscription.java
@@ -10,8 +10,6 @@ import com.google.gson.annotations.SerializedName;
 import java.util.HashMap;
 import java.util.Map;
 
-import euromsg.com.euromobileandroid.utils.EuroLogger;
-
 public class Subscription extends BaseRequest implements Cloneable {
 
     @SerializedName("appVersion")

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/PushNotificationManager.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/PushNotificationManager.java
@@ -81,7 +81,9 @@ public class PushNotificationManager {
                 channelId += pushMessage.getSound();
             }
 
-            mNotificationManager.notify(notificationId, mBuilder.build());
+            if(mNotificationManager != null) {
+                mNotificationManager.notify(notificationId, mBuilder.build());
+            }
 
         } catch (Exception e) {
             EuroLogger.debugLog("Generate notification : " + e.getMessage());
@@ -102,8 +104,8 @@ public class PushNotificationManager {
                 .setLargeIcon(largeIcon)
                 .setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
                 .setAutoCancel(true);
-        mBuilder = setNumber(mBuilder, context);
-        mBuilder = setNotificationSmallIcon(mBuilder, context);
+        setNumber(mBuilder, context);
+        setNotificationSmallIcon(mBuilder, context);
 
         return mBuilder;
     }
@@ -128,9 +130,9 @@ public class PushNotificationManager {
                 .setAutoCancel(true)
                 .setContentText(pushMessage.getMessage());
 
-        mBuilder = setNumber(mBuilder, context);
+        setNumber(mBuilder, context);
 
-        mBuilder = setNotificationSmallIcon(mBuilder, context);
+        setNotificationSmallIcon(mBuilder, context);
 
         if (pushMessage.getSound() != null) {
             mBuilder.setSound(AppUtils.getSound(context, pushMessage.getSound()));
@@ -173,14 +175,13 @@ public class PushNotificationManager {
         return AppUtils.getApplicationName(context);
     }
 
-    private NotificationCompat.Builder setNumber(NotificationCompat.Builder mBuilder, Context context) {
+    private void setNumber(NotificationCompat.Builder mBuilder, Context context) {
         if (SharedPreference.getInt(context, Constants.BADGE) == Constants.ACTIVE) {
             mBuilder.setNumber(1).setBadgeIconType(NotificationCompat.BADGE_ICON_SMALL);
         }
-        return mBuilder;
     }
 
-    private NotificationCompat.Builder setNotificationSmallIcon(NotificationCompat.Builder builder, Context context) {
+    private void setNotificationSmallIcon(NotificationCompat.Builder builder, Context context) {
 
         int transparentSmallIcon = SharedPreference.getInt(context, Constants.NOTIFICATION_TRANSPARENT_SMALL_ICON);
 
@@ -194,6 +195,5 @@ public class PushNotificationManager {
             String color = SharedPreference.getString(context, Constants.NOTIFICATION_COLOR);
             builder.setColor(Color.parseColor(color));
         }
-        return builder;
     }
 }

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/PushNotificationManager.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/PushNotificationManager.java
@@ -21,7 +21,6 @@ import androidx.core.app.NotificationCompat;
 import java.util.ArrayList;
 
 import euromsg.com.euromobileandroid.Constants;
-import euromsg.com.euromobileandroid.R;
 import euromsg.com.euromobileandroid.notification.carousel.CarouselBuilder;
 import euromsg.com.euromobileandroid.model.CarouselItem;
 import euromsg.com.euromobileandroid.model.Element;

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/PushNotificationManager.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/PushNotificationManager.java
@@ -144,7 +144,7 @@ public class PushNotificationManager {
     }
 
     @TargetApi(Build.VERSION_CODES.O)
-    public void createNotificationChannel(NotificationManager notificationManager, String channelId, String sound, Context context) {
+    public static void createNotificationChannel(NotificationManager notificationManager, String channelId, String sound, Context context) {
 
         int importance = android.app.NotificationManager.IMPORTANCE_DEFAULT;
 
@@ -161,11 +161,11 @@ public class PushNotificationManager {
         notificationManager.createNotificationChannel(notificationChannel);
     }
 
-    private String getChannelDescription(Context context) {
+    public static String getChannelDescription(Context context) {
         return AppUtils.getApplicationName(context);
     }
 
-    private String getChannelName(Context context) {
+    public static String getChannelName(Context context) {
         if (!SharedPreference.getString(context, Constants.CHANNEL_NAME).equals("")) {
 
             return SharedPreference.getString(context, Constants.CHANNEL_NAME);

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/carousel/CarouselBuilder.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/notification/carousel/CarouselBuilder.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -37,6 +38,7 @@ public class CarouselBuilder implements Serializable {
     private String bigContentTitle, bigContentText; //title and text when it becomes large
     private String leftItemTitle, leftItemDescription;
     private String rightItemTitle, rightItemDescription;
+    private final String channelId = "euroChannel";
 
     Message message;
     private static final String TAG = "Carousel";
@@ -275,6 +277,10 @@ public class CarouselBuilder implements Serializable {
             setPendingIntents(bigView);
 
             NotificationManager mNotifyManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && mNotifyManager != null) {
+                PushNotificationManager.createNotificationChannel(mNotifyManager, channelId, message.getSound(), context);
+            }
 
             PushNotificationManager pushNotificationManager = new PushNotificationManager();
 

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroFirebaseMessagingService.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroFirebaseMessagingService.java
@@ -77,11 +77,6 @@ public class EuroFirebaseMessagingService extends FirebaseMessagingService {
                     pushNotificationManager.generateNotification(this, pushMessage, null, notificationId);
                     break;
             }
-
-            String appAlias = SharedPreference.getString(this, Constants.GOOGLE_APP_ALIAS);
-            String huaweiAppAlias = SharedPreference.getString(this, Constants.HUAWEI_APP_ALIAS);
-
-            EuroMobileManager.init(appAlias, huaweiAppAlias, this).reportReceived(pushMessage.getPushId());
         } else {
             EuroLogger.debugLog("remoteMessageData transfrom problem");
         }

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroFirebaseMessagingService.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroFirebaseMessagingService.java
@@ -27,7 +27,10 @@ public class EuroFirebaseMessagingService extends FirebaseMessagingService {
     public void onNewToken(@NonNull String token) {
         try {
             EuroLogger.debugLog("On new token : " + token);
-            EuroMobileManager.getInstance().subscribe(token, this);
+            String gooleAppAlias = SharedPreference.getString(this, Constants.GOOGLE_APP_ALIAS);
+            String huaweiAppAlias = SharedPreference.getString(this, Constants.HUAWEI_APP_ALIAS);
+            EuroMobileManager.init(gooleAppAlias, huaweiAppAlias, this).subscribe(token, this);
+
         } catch (Exception e) {
             EuroLogger.debugLog(e.toString());
             EuroLogger.debugLog("Failed to complete token refresh");

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroFirebaseMessagingService.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroFirebaseMessagingService.java
@@ -1,7 +1,5 @@
 package euromsg.com.euromobileandroid.service;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import com.google.firebase.messaging.FirebaseMessagingService;

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroHuaweiMessagingService.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroHuaweiMessagingService.java
@@ -99,11 +99,6 @@ public class EuroHuaweiMessagingService extends HmsMessageService {
                         pushNotificationManager.generateNotification(this, pushMessage, null, notificationId);
                         break;
                 }
-
-                String huaweiAppAlias = SharedPreference.getString(this, Constants.HUAWEI_APP_ALIAS);
-                String googleAppAlias = SharedPreference.getString(this, Constants.GOOGLE_APP_ALIAS);
-
-                EuroMobileManager.init(googleAppAlias,huaweiAppAlias, this).reportReceived(pushMessage.getPushId());
             } else {
                 EuroLogger.debugLog("remoteMessageData transfrom problem");
             }

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroHuaweiMessagingService.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroHuaweiMessagingService.java
@@ -43,7 +43,9 @@ public class EuroHuaweiMessagingService extends HmsMessageService {
     public void onNewToken(String token) {
         if (!checkPlayService()) {
             if (!TextUtils.isEmpty(token)) {
-                EuroMobileManager.getInstance().subscribe(token, this);
+                String gooleAppAlias = SharedPreference.getString(this, Constants.GOOGLE_APP_ALIAS);
+                String huaweiAppAlias = SharedPreference.getString(this, Constants.HUAWEI_APP_ALIAS);
+                EuroMobileManager.init(gooleAppAlias, huaweiAppAlias, this).subscribe(token, this);
                 Log.i(TAG, "Huawei Token refresh token:" + token);
             }
         } else {

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroHuaweiMessagingService.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/service/EuroHuaweiMessagingService.java
@@ -82,7 +82,7 @@ public class EuroHuaweiMessagingService extends HmsMessageService {
                         if (pushMessage.getElements() != null) {
                             pushNotificationManager.generateCarouselNotification(this, pushMessage, notificationId);
                         } else {
-                            pushNotificationManager.generateNotification(this, pushMessage, AppUtils.getBitmap(pushMessage.getMediaUrl()), notificationId);
+                            pushNotificationManager.generateNotification(this, pushMessage, AppUtils.getBitMapFromUri(pushMessage.getMediaUrl()), notificationId);
                         }
 
                         break;

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
@@ -137,32 +137,6 @@ public final class AppUtils {
         return image;
     }
 
-    public static Bitmap getBitmap(final String photoUrl) {
-            Bitmap imageBitmap;
-            try {
-                imageBitmap = new AsyncTask<Void, Void, Bitmap>() {
-                    @Override
-                    protected Bitmap doInBackground(Void... params) {
-                        try {
-                            return Picasso.get().load(String.valueOf(photoUrl))
-                                    .get();
-                        } catch (IOException e) {
-                            e.printStackTrace();
-                        }
-                        return getBitMapFromUri(photoUrl);
-                    }
-                }.execute().get();
-            } catch (InterruptedException e) {
-                imageBitmap = getBitMapFromUri(photoUrl);
-                e.printStackTrace();
-            } catch (ExecutionException e) {
-                imageBitmap = getBitMapFromUri(photoUrl);
-                e.printStackTrace();
-            }
-        return imageBitmap;
-
-    }
-
     @SuppressLint("MissingPermission")
     public static String deviceUDID(Context context) {
 

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
@@ -172,8 +172,14 @@ public final class AppUtils {
                         .getSystemService(Context.TELEPHONY_SERVICE);
                 if (hasReadPhoneStatePermission(context)) {
                     try {
-                        if (tm.getDeviceId() != null) {
-                            return tm.getDeviceId(); // unique identifier from phone
+                        String deviceId = ""; //IMEI
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            deviceId = tm.getImei();
+                        } else {
+                            deviceId = tm.getDeviceId();
+                        }
+                        if (deviceId != null) {
+                            return deviceId; // unique identifier from phone
                         } else {
                             return Secure.getString(context.getContentResolver(),
                                     Secure.ANDROID_ID); // if device id not available get OS

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
@@ -195,7 +195,7 @@ public final class AppUtils {
                 askForReadPhoneStatePermission(null, 1200);
             }
         } catch (Exception e) {
-            //TODO Log here
+            Log.e("Read Device ID : ", "Could not get device id");
         }
         return id(context);
     }

--- a/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
+++ b/euromsg/src/main/java/euromsg/com/euromobileandroid/utils/AppUtils.java
@@ -12,12 +12,8 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Build;
-import android.os.Bundle;
 import android.os.StrictMode;
 import android.provider.Settings.Secure;
 import android.telephony.TelephonyManager;
@@ -25,8 +21,6 @@ import android.util.Log;
 
 import androidx.core.content.PermissionChecker;
 import androidx.fragment.app.Fragment;
-
-import com.squareup.picasso.Picasso;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -39,7 +33,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 import euromsg.com.euromobileandroid.model.Message;
 


### PR DESCRIPTION
- 1st commit (Removes RxAndroid from the demo app) : 
   RxAndroid's dependencies and usages are removed to make the demo app more clear and understandable. (since the main purpose of the demo app is showing the usage of the sdk)

- 2nd commit (Adds a control to check if firabase or huawei) : 
   Wraps getFirebaseToken() and getHuaweiToken() methods with and if/else statement in order not to call both unnecessarily.

- 3rd commit (Fixes a logical mistake) :
   It was thought that both the token and the appAlias are necessary to make a subscription valid at this commit but in a commit later it will be reverted to AND again.

- 4th commit (Changes a method's name which seems to be wrong) :
   The previous name of the method (isSubscriptionAllReadySent()) was not reflecting the work of the method correctly. Thus, it is changed to isSubscriptionAlreadySent()

- 5th commit (Adds a control for token changes in background) : 
   In case of a change on Firabase or Huwaei tokens when the app is closed, the structure is changed so that this case will also be covered. 
   To get device ID for api levels greater than 26 (Version O), getImei() method is used.
   The change made in commit 3 above (AND -> OR) is reverted . It is now the same as the one before this branch.

- 6th commit (Update libraries, get SDK_VERSION from gradle file) :
  The libraries in both app module's and sdk module's build.gradle files are updated to the last versions.
  In demo app, versioning is corrected (one shown on the demo app's screen) (It was showing the Firebase versions)
  The value of the constant SDK_VERSION is now being gotten from the build.gradle.

- 7th commit (Bug fix for carousel notification) :
  There was no statement to create a notification channel for carousel notifications. Thus, if a carousel notification is used first after the app installation, the notification was not appearing. After using a text notification or single-image notification, it was starting to appear since the notification channel is created for these types. A statement is added to create the notification channel on the path of building a carousel notification.

- 8th commit (Removes an unnecessary method and revert a change) : 
  getBitmap() method in AppUtils.java is removed since there is another and better method that does the exact same job, getBitMapFromUri(). There were 2 usages of getBitmap() : EuroHuaweiMessagingServive (Firabase was using getBitMapFromUri) and demo app. Both usages are changed to getBitMapFromUri() for consistency.
  A change made by me before is removed since it is understood that is has no effect.

- 9th commit (Remove unnecessary imports and replace AsyncTask) :
  Unused import statements are removed from all files. 
  AsyncTask used in CarouselImageDownloader.downloadImage() method is replaced with the Thread/Runnable structure since it is deprecated in Android R.

- 10th commit (Removes reportReceived() method) : 
  Removes reportReceived() method since it is redundant. Saving the token to SharedPreferences in the subscribe() method had been added for reportReceived() method so it is also removed.

- 11th commit (Replaces findViewByIds by viewBinding) : 
  findViewByIds are replaced with viewBinding to lessen the code.


NOTES: 

- If it turns out that in order a subscription be valid, both token and appAlias must be available then AND statement in Subscription.isValid() method should be replaced with OR statement.

- After each change above, I tested the notifications via both demo app buttons and RMC. 